### PR TITLE
fix: fix publish release workflow to add permissions

### DIFF
--- a/.github/workflows/run_publish.yml
+++ b/.github/workflows/run_publish.yml
@@ -10,3 +10,5 @@ jobs:
   publish:
     uses: ./.github/workflows/publish.yml
     secrets: inherit
+    permissions:
+      id-token: write


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/run_publish.yml` file. The change adds permissions for the `id-token` with write access to the `publish` job.

* [`.github/workflows/run_publish.yml`](diffhunk://#diff-238154cd5578ddea8948801df1255a4ecdb17a732daf349947461a01afeb62d8R13-R14): Added `permissions` for `id-token` with write access to the `publish` job.